### PR TITLE
Make EG url to consume KubeDNS

### DIFF
--- a/roles/jupyterhub/templates/jupyterhub-config.yaml.j2
+++ b/roles/jupyterhub/templates/jupyterhub-config.yaml.j2
@@ -49,7 +49,7 @@ singleuser:
       storageClass: nfs-dynamic
     capacity: 2Gi
   extraEnv:
-    KG_URL: http://{{ groups['ingress'][0] }}
+    KG_URL: http://enterprise-gateway.enterprise-gateway:8888
     KG_REQUEST_TIMEOUT: 60
 
 rbac:


### PR DESCRIPTION
Since we will be install EG in the same package, we can assume that EG will be on the same cluster and can be accessible using KubeDNS. This way JupyterLab will work as it without configuring any value.